### PR TITLE
fix: correct bugs URL and clean up documentation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,11 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(rm:*)",
-      "Bash(ls:*)",
-      "Bash(DEBUG=license-checker-evergreen*)",
-      "Bash(timeout 60s npm test tests/test.ts -- --testNamePattern=\"should parse local with unknown and give us results\")"
-    ],
+    "allow": [],
     "deny": []
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn
 .vscode/
 .zed/
+.claude
 artifacts
 coverage/
 CVS/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,13 @@
 
 ## [5.0.5] - 2025-10-05
 
-### 🚀 Features
-
-### 🐛 Bug Fixes
-
 ### 🔧 Improvements
 - bump version to 5.0.5 [skip ci]
 
-### 📚 Documentation
-
-### Other Changes
-
-
-
-
 ## [5.0.4] - 2025-10-05
-
-### 🚀 Features
-
-### 🐛 Bug Fixes
 
 ### 🔧 Improvements
 - bump version to 5.0.4 [skip ci]
-
-### 📚 Documentation
-
-### Other Changes
-
-
-
 
 ## [5.0.3] - 2025-10-05
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     },
     "preferGlobal": true,
     "bugs": {
-        "url": "http://github.com/evergreen/license-checker-evergreen/issues"
+        "url": "http://github.com/greenstevester/license-checker-evergreen/issues"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary
- Fix incorrect bugs URL in package.json (evergreen → greenstevester)
- Remove empty sections from CHANGELOG v5.0.5 and v5.0.4
- Add .claude directory to gitignore to prevent IDE settings from being tracked

## Changes

### Critical Fixes
- **package.json**: Corrected bugs URL from `evergreen/license-checker-evergreen` to `greenstevester/license-checker-evergreen`
  - This fixes 404 errors when users try to report issues

### Documentation Improvements
- **CHANGELOG.md**: Removed empty sections (Features, Bug Fixes, Documentation, Other Changes) from v5.0.5 and v5.0.4
  - Improves readability and maintainability
  - Reduces file by 22 lines

### Development Environment
- **gitignore**: Added `.claude` directory to prevent Claude Code local settings from being tracked
- **settings.local.json**: Cleared permissions for clean environment

## Test Plan
- ✅ All 81 tests passing
- ✅ Build succeeds without errors
- ✅ Linting passes (only pre-existing warnings)
- ✅ No breaking changes

## Impact
- Users can now correctly report issues via the bugs URL
- Cleaner, more maintainable CHANGELOG
- Better developer experience with IDE settings properly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)