### PR TITLE
fix(security): resolve 26 npm audit advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 🔒 Security
+- Resolve 26 `npm audit` advisories (2 critical, 21 high, 2 moderate, 1 low) via in-range updates to the lockfile. All fixes are semver-compatible; the `dependencies` block is unchanged, so published CLI behavior is unaffected ([#1](https://github.com/danshome/license-checker-evergreen/issues/1)).
+- Pin the `read-installed` → `glob@7` → `minimatch` → `brace-expansion` prod-path via scoped `overrides` to lock the patched transitive versions against future re-resolution.
+
 ## [6.2.1] - 2026-04-11
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,523 +194,475 @@
             }
         },
         "node_modules/@aws-sdk/client-ses": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.948.0.tgz",
-            "integrity": "sha512-325xqg08RSKbeWAW2GMrCRABTjFR3sqA2bBlihlUj6wcijw0XAdB3roYu+29W5vSnq6igbcFAlLgr8RRlKHnpQ==",
+            "version": "3.1032.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1032.0.tgz",
+            "integrity": "sha512-vix6Nwzzml9Kr0qZST6UAmEzJpCFfsBZEy5F5BwipNo2n4bIVgYZ/pqRAXhtvxU7YZEvYoAJJuozJ6mNzHChOA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/credential-provider-node": "3.948.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/util-waiter": "^4.2.5",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/credential-provider-node": "^3.972.32",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.31",
+                "@aws-sdk/region-config-resolver": "^3.972.12",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.7",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.17",
+                "@smithy/config-resolver": "^4.4.16",
+                "@smithy/core": "^3.23.15",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.30",
+                "@smithy/middleware-retry": "^4.5.3",
+                "@smithy/middleware-serde": "^4.2.18",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.5.3",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.47",
+                "@smithy/util-defaults-mode-node": "^4.2.52",
+                "@smithy/util-endpoints": "^3.4.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/util-waiter": "^4.2.16",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-            "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
-            "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
+            "version": "3.974.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
+            "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.7",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/xml-builder": "^3.972.18",
+                "@smithy/core": "^3.23.15",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-            "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
+            "version": "3.972.27",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
+            "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-            "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
+            "version": "3.972.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
+            "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.5.3",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.23",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-            "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
+            "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/credential-provider-env": "3.947.0",
-                "@aws-sdk/credential-provider-http": "3.947.0",
-                "@aws-sdk/credential-provider-login": "3.948.0",
-                "@aws-sdk/credential-provider-process": "3.947.0",
-                "@aws-sdk/credential-provider-sso": "3.948.0",
-                "@aws-sdk/credential-provider-web-identity": "3.948.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/credential-provider-env": "^3.972.27",
+                "@aws-sdk/credential-provider-http": "^3.972.29",
+                "@aws-sdk/credential-provider-login": "^3.972.31",
+                "@aws-sdk/credential-provider-process": "^3.972.27",
+                "@aws-sdk/credential-provider-sso": "^3.972.31",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+                "@aws-sdk/nested-clients": "^3.996.21",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-            "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
+            "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/nested-clients": "^3.996.21",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-            "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
+            "version": "3.972.32",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
+            "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.947.0",
-                "@aws-sdk/credential-provider-http": "3.947.0",
-                "@aws-sdk/credential-provider-ini": "3.948.0",
-                "@aws-sdk/credential-provider-process": "3.947.0",
-                "@aws-sdk/credential-provider-sso": "3.948.0",
-                "@aws-sdk/credential-provider-web-identity": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/credential-provider-env": "^3.972.27",
+                "@aws-sdk/credential-provider-http": "^3.972.29",
+                "@aws-sdk/credential-provider-ini": "^3.972.31",
+                "@aws-sdk/credential-provider-process": "^3.972.27",
+                "@aws-sdk/credential-provider-sso": "^3.972.31",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-            "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
+            "version": "3.972.27",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
+            "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-            "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
+            "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.948.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/token-providers": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/nested-clients": "^3.996.21",
+                "@aws-sdk/token-providers": "3.1032.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-            "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
+            "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/nested-clients": "^3.996.21",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-            "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+            "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-            "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+            "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-            "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+            "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
+                "@aws-sdk/types": "^3.973.8",
                 "@aws/lambda-invoke-store": "^0.2.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-            "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
+            "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@smithy/core": "^3.18.7",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.7",
+                "@smithy/core": "^3.23.15",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-retry": "^4.3.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-            "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
+            "version": "3.996.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
+            "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.31",
+                "@aws-sdk/region-config-resolver": "^3.972.12",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.7",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.17",
+                "@smithy/config-resolver": "^4.4.16",
+                "@smithy/core": "^3.23.15",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.30",
+                "@smithy/middleware-retry": "^4.5.3",
+                "@smithy/middleware-serde": "^4.2.18",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.5.3",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.47",
+                "@smithy/util-defaults-mode-node": "^4.2.52",
+                "@smithy/util-endpoints": "^3.4.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-            "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+            "version": "3.972.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+            "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/config-resolver": "^4.4.16",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-            "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
+            "version": "3.1032.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
+            "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.1",
+                "@aws-sdk/nested-clients": "^3.996.21",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
-            "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+            "version": "3.973.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+            "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-            "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+            "version": "3.996.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+            "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-endpoints": "^3.4.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.893.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
-            "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-            "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+            "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-            "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
+            "version": "3.973.17",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
+            "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/middleware-user-agent": "^3.972.31",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "aws-crt": ">=1.0.0"
@@ -722,24 +674,24 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "version": "3.972.18",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+            "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "fast-xml-parser": "5.2.5",
+                "@smithy/types": "^4.14.1",
+                "fast-xml-parser": "5.5.8",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws/lambda-invoke-store": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
-            "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1807,9 +1759,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1818,9 +1770,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1881,9 +1833,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1902,9 +1854,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2001,29 +1953,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
-            }
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -3134,32 +3063,18 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-            "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-            "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+            "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-config-provider": "^4.2.0",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.4.1",
+                "@smithy/util-middleware": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3167,21 +3082,21 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.18.7",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
-            "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
+            "version": "3.23.15",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+            "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.23",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3189,16 +3104,16 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-            "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+            "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3206,16 +3121,16 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-            "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+            "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3223,15 +3138,15 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-            "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+            "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3239,13 +3154,13 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-            "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+            "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3253,9 +3168,9 @@
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3266,14 +3181,14 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-            "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+            "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3281,19 +3196,19 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.3.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
-            "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
+            "version": "4.4.30",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+            "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/core": "^3.23.15",
+                "@smithy/middleware-serde": "^4.2.18",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-middleware": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3301,20 +3216,21 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
-            "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+            "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/uuid": "^1.1.0",
+                "@smithy/core": "^3.23.15",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/service-error-classification": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.2",
+                "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3322,14 +3238,15 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-            "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+            "version": "4.2.18",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+            "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/core": "^3.23.15",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3337,13 +3254,13 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-            "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+            "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3351,15 +3268,15 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-            "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+            "version": "4.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+            "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3367,16 +3284,15 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-            "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+            "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3384,13 +3300,13 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-            "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+            "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3398,13 +3314,13 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-            "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+            "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3412,14 +3328,14 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-            "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+            "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-uri-escape": "^4.2.0",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-uri-escape": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3427,13 +3343,13 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-            "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+            "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3441,26 +3357,26 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-            "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+            "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0"
+                "@smithy/types": "^4.14.1"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-            "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+            "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3468,19 +3384,19 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-            "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+            "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3488,18 +3404,18 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.9.10",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
-            "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
+            "version": "4.12.11",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+            "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
+                "@smithy/core": "^3.23.15",
+                "@smithy/middleware-endpoint": "^4.4.30",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.23",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3507,9 +3423,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-            "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+            "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3520,14 +3436,14 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-            "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+            "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/querystring-parser": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3535,14 +3451,14 @@
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3550,9 +3466,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3563,9 +3479,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3576,13 +3492,13 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/is-array-buffer": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3590,9 +3506,9 @@
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3603,15 +3519,15 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.13",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
-            "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
+            "version": "4.3.47",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+            "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3619,18 +3535,18 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.16",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
-            "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
+            "version": "4.2.52",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+            "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
+                "@smithy/config-resolver": "^4.4.16",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.11",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3638,14 +3554,14 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-            "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+            "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3653,9 +3569,9 @@
             }
         },
         "node_modules/@smithy/util-hex-encoding": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3666,13 +3582,13 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-            "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+            "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3680,14 +3596,14 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-            "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+            "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/service-error-classification": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3695,19 +3611,19 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-            "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+            "version": "4.5.23",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+            "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.5.3",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3715,9 +3631,9 @@
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3728,13 +3644,13 @@
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-buffer-from": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3742,14 +3658,13 @@
             }
         },
         "node_modules/@smithy/util-waiter": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
-            "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+            "version": "4.2.16",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+            "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3757,9 +3672,9 @@
             }
         },
         "node_modules/@smithy/uuid": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-            "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4566,9 +4481,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4853,16 +4768,16 @@
             "license": "MIT"
         },
         "node_modules/bowser": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-            "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5358,9 +5273,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -5630,9 +5545,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5681,9 +5596,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5888,10 +5803,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-xml-parser": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+        "node_modules/fast-xml-builder": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "dev": true,
             "funding": [
                 {
@@ -5901,7 +5816,25 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "strnum": "^2.1.0"
+                "path-expression-matcher": "^1.1.3"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.5.8",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+            "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "fast-xml-builder": "^1.1.4",
+                "path-expression-matcher": "^1.2.0",
+                "strnum": "^2.2.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -5975,9 +5908,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -6212,9 +6145,9 @@
             "license": "MIT"
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7448,9 +7381,9 @@
             }
         },
         "node_modules/jest-util/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7767,9 +7700,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -7959,13 +7892,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -8358,6 +8291,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8415,9 +8364,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8646,9 +8595,9 @@
             }
         },
         "node_modules/read-installed/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -8683,9 +8632,9 @@
             "license": "ISC"
         },
         "node_modules/read-installed/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8861,6 +8810,29 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "13.0.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
@@ -8890,16 +8862,16 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -9321,9 +9293,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "dev": true,
             "funding": [
                 {
@@ -9390,9 +9362,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9423,9 +9395,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9471,9 +9443,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -202,6 +202,10 @@
     "overrides": {
         "@octokit/plugin-paginate-rest": "^11.3.6",
         "@octokit/request": "^9.1.3",
-        "@octokit/request-error": "^6.1.5"
+        "@octokit/request-error": "^6.1.5",
+        "read-installed": {
+            "minimatch": "^3.1.5",
+            "brace-expansion": "^1.1.14"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Resolves all **26 open `npm audit` advisories** (2 critical, 21 high, 2 moderate, 1 low) with **zero change to the `dependencies` block** and no semver drift for published CLI consumers.

## Before → after

| Severity | Before | After |
|---|---|---|
| critical | 2 | 0 |
| high | 21 | 0 |
| moderate | 2 | 0 |
| low | 1 | 0 |
| **total** | **26** | **0** |

## What changed

- `npm audit fix` (no `--force`) — all 26 advisories had in-range, semver-compatible fixes available. No major-version bumps.
- Added a **scoped `overrides` entry** for the one prod-path concern (`read-installed` → `glob@7` → `minimatch` → `brace-expansion`) to lock the patched transitive versions against future re-resolution:

  ```json
  "read-installed": {
    "minimatch": "^3.1.5",
    "brace-expansion": "^1.1.14"
  }
  ```

  Scoped to `read-installed` so dev-deps that legitimately use `minimatch@9/10` or `brace-expansion@2/5` (e.g. `@typescript-eslint`, `rimraf`, `jest`) stay on their current versions.

## Scope analysis

25 of 26 advisories were in `devDependencies` only — they don't ship to CLI users. The single prod-path fix moves `brace-expansion` from 1.1.12 → 1.1.14 (patch, same semver range). No public API or CLI behavior change.

## Test plan

- [x] `npm audit` → 0 vulnerabilities.
- [x] `npm run build` clean.
- [x] `npm test` → 231 passed, 1 pre-existing skip, 0 failed.
- [x] `dependencies` semver ranges unchanged.
- [x] No changes to `src/`; no public API or CLI behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)