### PR TITLE
fix(deps): resolve all npm audit vulnerabilities (26 → 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,21 @@
                 "npm": ">=8"
             }
         },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -72,47 +87,6 @@
                 "@aws-sdk/util-locate-window": "^3.0.0",
                 "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-crypto/sha256-js": {
@@ -152,594 +126,308 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-ses": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.948.0.tgz",
-            "integrity": "sha512-325xqg08RSKbeWAW2GMrCRABTjFR3sqA2bBlihlUj6wcijw0XAdB3roYu+29W5vSnq6igbcFAlLgr8RRlKHnpQ==",
+            "version": "3.1053.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1053.0.tgz",
+            "integrity": "sha512-mjaaTJgJt0HFIitA4BKYKfstF4y3/P+JhZwcMMiWMQYfpFiMBOsd3zOBW9BbyW/137nEJKgtPMvTGD/PqmciWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/credential-provider-node": "3.948.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/util-waiter": "^4.2.5",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/credential-provider-node": "^3.972.44",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.948.0.tgz",
-            "integrity": "sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
-            "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
+            "version": "3.974.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
+            "integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.7",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
+                "@aws-sdk/types": "^3.973.9",
+                "@aws-sdk/xml-builder": "^3.972.25",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/core": "^3.24.3",
+                "@smithy/signature-v4": "^5.4.2",
+                "@smithy/types": "^4.14.2",
+                "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.947.0.tgz",
-            "integrity": "sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==",
+            "version": "3.972.39",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
+            "integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.947.0.tgz",
-            "integrity": "sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==",
+            "version": "3.972.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
+            "integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.948.0.tgz",
-            "integrity": "sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==",
+            "version": "3.972.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
+            "integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/credential-provider-env": "3.947.0",
-                "@aws-sdk/credential-provider-http": "3.947.0",
-                "@aws-sdk/credential-provider-login": "3.948.0",
-                "@aws-sdk/credential-provider-process": "3.947.0",
-                "@aws-sdk/credential-provider-sso": "3.948.0",
-                "@aws-sdk/credential-provider-web-identity": "3.948.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/credential-provider-env": "^3.972.39",
+                "@aws-sdk/credential-provider-http": "^3.972.41",
+                "@aws-sdk/credential-provider-login": "^3.972.43",
+                "@aws-sdk/credential-provider-process": "^3.972.39",
+                "@aws-sdk/credential-provider-sso": "^3.972.43",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+                "@aws-sdk/nested-clients": "^3.997.11",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/credential-provider-imds": "^4.3.2",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.948.0.tgz",
-            "integrity": "sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==",
+            "version": "3.972.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
+            "integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/nested-clients": "^3.997.11",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.948.0.tgz",
-            "integrity": "sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==",
+            "version": "3.972.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
+            "integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.947.0",
-                "@aws-sdk/credential-provider-http": "3.947.0",
-                "@aws-sdk/credential-provider-ini": "3.948.0",
-                "@aws-sdk/credential-provider-process": "3.947.0",
-                "@aws-sdk/credential-provider-sso": "3.948.0",
-                "@aws-sdk/credential-provider-web-identity": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/credential-provider-env": "^3.972.39",
+                "@aws-sdk/credential-provider-http": "^3.972.41",
+                "@aws-sdk/credential-provider-ini": "^3.972.43",
+                "@aws-sdk/credential-provider-process": "^3.972.39",
+                "@aws-sdk/credential-provider-sso": "^3.972.43",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.43",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/credential-provider-imds": "^4.3.2",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.947.0.tgz",
-            "integrity": "sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==",
+            "version": "3.972.39",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
+            "integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.948.0.tgz",
-            "integrity": "sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==",
+            "version": "3.972.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
+            "integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.948.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/token-providers": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/nested-clients": "^3.997.11",
+                "@aws-sdk/token-providers": "3.1052.0",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.948.0.tgz",
-            "integrity": "sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==",
+            "version": "3.972.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
+            "integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/nested-clients": "^3.997.11",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
-            "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
-            "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.948.0.tgz",
-            "integrity": "sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@aws/lambda-invoke-store": "^0.2.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.947.0.tgz",
-            "integrity": "sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@smithy/core": "^3.18.7",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.948.0.tgz",
-            "integrity": "sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==",
+            "version": "3.997.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
+            "integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/middleware-host-header": "3.936.0",
-                "@aws-sdk/middleware-logger": "3.936.0",
-                "@aws-sdk/middleware-recursion-detection": "3.948.0",
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/region-config-resolver": "3.936.0",
-                "@aws-sdk/types": "3.936.0",
-                "@aws-sdk/util-endpoints": "3.936.0",
-                "@aws-sdk/util-user-agent-browser": "3.936.0",
-                "@aws-sdk/util-user-agent-node": "3.947.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.7",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-retry": "^4.4.14",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.13",
-                "@smithy/util-defaults-mode-node": "^4.2.16",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.28",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
-            "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.28",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
+            "integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/signature-v4": "^5.4.2",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.948.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.948.0.tgz",
-            "integrity": "sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==",
+            "version": "3.1052.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
+            "integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.947.0",
-                "@aws-sdk/nested-clients": "3.948.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
+                "@aws-sdk/core": "^3.974.13",
+                "@aws-sdk/nested-clients": "^3.997.11",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
-            "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+            "version": "3.973.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+            "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
-            "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.893.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
-            "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.936.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
-            "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.947.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.947.0.tgz",
-            "integrity": "sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.947.0",
-                "@aws-sdk/types": "3.936.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "version": "3.972.25",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
+            "integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "fast-xml-parser": "5.2.5",
+                "@nodable/entities": "2.1.0",
+                "@smithy/types": "^4.14.2",
+                "fast-xml-parser": "5.7.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@aws/lambda-invoke-store": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
-            "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1807,9 +1495,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1818,9 +1506,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1881,9 +1569,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1902,9 +1590,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2001,29 +1689,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
-            }
-        },
-        "node_modules/@isaacs/balanced-match": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/@isaacs/brace-expansion": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@isaacs/balanced-match": "^4.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -2764,6 +2429,19 @@
                 "@tybys/wasm-util": "^0.10.0"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@octokit/auth-token": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -3134,54 +2812,15 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-            "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/config-resolver": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-            "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-config-provider": "^4.2.0",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/core": {
-            "version": "3.18.7",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
-            "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
+            "version": "3.24.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
+            "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3189,16 +2828,14 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-            "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
+            "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
+                "@smithy/core": "^3.24.4",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3206,46 +2843,14 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-            "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
+            "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-node": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-            "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/invalid-dependency": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-            "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/core": "^3.24.4",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3253,214 +2858,27 @@
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-content-length": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-            "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.3.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
-            "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-serde": "^4.2.6",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
-            "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/uuid": "^1.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-serde": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-            "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-stack": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-            "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/node-config-provider": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-            "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-            "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
+            "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/querystring-builder": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/property-provider": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-            "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/protocol-http": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-            "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-            "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-            "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/service-error-classification": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-            "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-            "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
+                "@smithy/core": "^3.24.4",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3468,38 +2886,14 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-            "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
+            "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/smithy-client": {
-            "version": "4.9.10",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
-            "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/core": "^3.18.7",
-                "@smithy/middleware-endpoint": "^4.3.14",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
+                "@smithy/core": "^3.24.4",
+                "@smithy/types": "^4.14.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3507,65 +2901,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-            "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/url-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-            "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-base64": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-body-length-browser": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-body-length-node": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+            "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3576,197 +2914,31 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/is-array-buffer": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-config-provider": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.13",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
-            "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.16",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
-            "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/smithy-client": "^4.9.10",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-endpoints": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-            "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-hex-encoding": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-middleware": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-            "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-retry": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-            "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-            "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-buffer-from": "^4.2.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-buffer-from": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
-            "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/uuid": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-            "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -4566,9 +3738,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4853,16 +4025,16 @@
             "license": "MIT"
         },
         "node_modules/bowser": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-            "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5358,9 +4530,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -5630,9 +4802,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5681,9 +4853,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5888,10 +5060,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-xml-parser": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "dev": true,
             "funding": [
                 {
@@ -5901,7 +5073,27 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "strnum": "^2.1.0"
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.7",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -5975,9 +5167,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -6212,9 +5404,9 @@
             "license": "MIT"
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7448,9 +6640,9 @@
             }
         },
         "node_modules/jest-util/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7767,9 +6959,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -7959,13 +7151,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -8358,6 +7550,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8415,9 +7623,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8646,9 +7854,9 @@
             }
         },
         "node_modules/read-installed/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -8683,9 +7891,9 @@
             "license": "ISC"
         },
         "node_modules/read-installed/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8861,6 +8069,29 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/rimraf/node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "13.0.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
@@ -8890,16 +8121,16 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "@isaacs/brace-expansion": "^5.0.0"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -9321,9 +8552,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
             "dev": true,
             "funding": [
                 {
@@ -9390,9 +8621,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9423,9 +8654,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -9471,9 +8702,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10155,6 +9386,22 @@
                 "is-typedarray": "^1.0.0",
                 "signal-exit": "^3.0.2",
                 "typedarray-to-buffer": "^3.1.5"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/y18n": {


### PR DESCRIPTION
## Summary

Clears all **26** `npm audit` advisories (2 critical, 5 high, 18 moderate, 1 low) that are currently failing the `security` CI job on every PR — via a **non-breaking** `npm audit fix`.

Notable advisories resolved: `fast-xml-parser` (critical), `handlebars` (critical), `lodash`, `minimatch`, `picomatch`, `flatted`, `@isaacs/brace-expansion`, `ajv`, and the whole `@aws-sdk/*` cascade (which rooted in `fast-xml-parser`).

## Approach — lowest risk

- **`package.json` is unchanged** — no direct-dependency bumps, no new `overrides`. The fix lives entirely in `package-lock.json` (transitive resolutions; mostly nested duplicate `minimatch`/`picomatch` copies deduped onto patched versions, net −753 lines).
- No `--force` / major version bumps, so no breaking changes to `jest`, `eslint`, etc.

## Verification (local, Node 24)

| Check | Result |
|---|---|
| `npm audit --audit-level=moderate` (CI step 1) | ✅ exit 0 — `found 0 vulnerabilities` |
| `npm audit --audit-level=high --production` (CI step 2) | ✅ exit 0 |
| `npm run build` (`tsc`) | ✅ exit 0 |
| `npm test` | ✅ 15 suites, 231 passed, 1 skipped |

## Notes

- The 1 `low`-severity advisory (`diff`) is below the `--audit-level=moderate` gate and is also resolved.
- Branched off `main`, independent of #9 (the lint/docs cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)