### PR TITLE
feat(action): add GitHub composite action + pin all workflows to SHA

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,0 +1,76 @@
+name: Test GitHub Action
+
+on:
+  push:
+    paths:
+      - 'action.yml'
+  pull_request:
+    paths:
+      - 'action.yml'
+  workflow_dispatch:
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+        -
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+
+      - name: Test default (JSON output)
+        id: json-test
+        uses: ./
+        with:
+          start: '.'
+
+      - name: Verify JSON output
+        run: |
+          echo "Packages found: ${{ steps.json-test.outputs.packages-count }}"
+          test -n "${{ steps.json-test.outputs.packages-count }}"
+
+      - name: Test production-only
+        uses: ./
+        with:
+          start: '.'
+          production: 'true'
+          output-format: 'summary'
+
+      - name: Test CSV output to file
+        uses: ./
+        with:
+          start: '.'
+          output-format: 'csv'
+          output-path: 'licenses.csv'
+
+      - name: Verify CSV file
+        run: |
+          test -f licenses.csv
+          head -1 licenses.csv | grep -q "module name"
+
+      - name: Test markdown output
+        uses: ./
+        with:
+          start: '.'
+          output-format: 'markdown'
+
+      - name: Test only-allow (should pass)
+        uses: ./
+        with:
+          start: '__tests__/fixtures/includeBSD'
+          only-allow: 'MIT;BSD-3-Clause;ISC;Apache-2.0;BSD-2-Clause;0BSD;Unlicense;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Python-2.0;BlueOak-1.0.0'
+
+      - name: Test exclude-private-packages
+        uses: ./
+        with:
+          start: '.'
+          exclude-private-packages: 'true'
+          output-format: 'json'

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -17,7 +17,6 @@ jobs:
         node-version: [18, 20, 22]
 
     steps:
-        -
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/competitor-tracking.yml
+++ b/.github/workflows/competitor-tracking.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
 
       # Reports stored as artifacts (private to repo owner)
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: competitor-report-${{ github.run_number }}
           path: |

--- a/.github/workflows/npm-stats-report-aws-ses.yml
+++ b/.github/workflows/npm-stats-report-aws-ses.yml
@@ -12,10 +12,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -167,7 +167,7 @@ jobs:
           mv license-checker-evergreen-${{ steps.extract_version.outputs.version }}.tgz license-checker-evergreen-v${{ steps.extract_version.outputs.version }}.tgz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,137 @@
+name: 'License Checker Evergreen'
+description: 'Scan, validate, and enforce open source license compliance in your project'
+author: 'greenstevester'
+
+branding:
+  icon: 'shield'
+  color: 'green'
+
+inputs:
+  start:
+    description: 'Path to the project to scan (default: current directory)'
+    required: false
+    default: '.'
+  production:
+    description: 'Only check production dependencies'
+    required: false
+    default: 'false'
+  fail-on:
+    description: 'Semicolon-separated list of licenses to fail on (e.g. "GPL-3.0;AGPL-3.0")'
+    required: false
+    default: ''
+  only-allow:
+    description: 'Semicolon-separated list of allowed licenses (e.g. "MIT;Apache-2.0;BSD-3-Clause")'
+    required: false
+    default: ''
+  exclude-packages:
+    description: 'Semicolon-separated list of packages to exclude'
+    required: false
+    default: ''
+  exclude-private-packages:
+    description: 'Exclude private packages from the check'
+    required: false
+    default: 'false'
+  output-format:
+    description: 'Output format: json, csv, markdown, tree, summary'
+    required: false
+    default: 'json'
+  output-path:
+    description: 'Write license report to this file path'
+    required: false
+    default: ''
+
+outputs:
+  report:
+    description: 'License report output (JSON string)'
+    value: ${{ steps.scan.outputs.report }}
+  packages-count:
+    description: 'Number of packages scanned'
+    value: ${{ steps.scan.outputs.packages_count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install license-checker-evergreen
+      shell: bash
+      run: npm install -g license-checker-evergreen@latest
+
+    - name: Run license check
+      id: scan
+      shell: bash
+      env:
+        INPUT_START: ${{ inputs.start }}
+        INPUT_PRODUCTION: ${{ inputs.production }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_ONLY_ALLOW: ${{ inputs.only-allow }}
+        INPUT_EXCLUDE_PACKAGES: ${{ inputs.exclude-packages }}
+        INPUT_EXCLUDE_PRIVATE: ${{ inputs.exclude-private-packages }}
+        INPUT_OUTPUT_FORMAT: ${{ inputs.output-format }}
+        INPUT_OUTPUT_PATH: ${{ inputs.output-path }}
+      run: |
+        set -euo pipefail
+
+        # Build CLI arguments
+        ARGS="--start ${INPUT_START}"
+
+        if [[ "${INPUT_PRODUCTION}" == "true" ]]; then
+          ARGS="${ARGS} --production"
+        fi
+
+        if [[ -n "${INPUT_FAIL_ON}" ]]; then
+          ARGS="${ARGS} --failOn ${INPUT_FAIL_ON}"
+        fi
+
+        if [[ -n "${INPUT_ONLY_ALLOW}" ]]; then
+          ARGS="${ARGS} --onlyAllow ${INPUT_ONLY_ALLOW}"
+        fi
+
+        if [[ -n "${INPUT_EXCLUDE_PACKAGES}" ]]; then
+          ARGS="${ARGS} --excludePackages ${INPUT_EXCLUDE_PACKAGES}"
+        fi
+
+        if [[ "${INPUT_EXCLUDE_PRIVATE}" == "true" ]]; then
+          ARGS="${ARGS} --excludePrivatePackages"
+        fi
+
+        # Set output format flag
+        case "${INPUT_OUTPUT_FORMAT}" in
+          csv)      ARGS="${ARGS} --csv" ;;
+          markdown) ARGS="${ARGS} --markdown" ;;
+          tree)     ARGS="${ARGS}" ;;
+          summary)  ARGS="${ARGS} --summary" ;;
+          *)        ARGS="${ARGS} --json" ;;
+        esac
+
+        # Set output file if specified
+        if [[ -n "${INPUT_OUTPUT_PATH}" ]]; then
+          ARGS="${ARGS} --out ${INPUT_OUTPUT_PATH}"
+        fi
+
+        echo "::group::License Check"
+        echo "Running: license-checker-evergreen ${ARGS}"
+
+        # Capture output for the report
+        OUTPUT=$(license-checker-evergreen ${ARGS} 2>&1) || {
+          EXIT_CODE=$?
+          echo "${OUTPUT}"
+          echo "::endgroup::"
+          echo "::error::License check failed (exit code ${EXIT_CODE})"
+          exit ${EXIT_CODE}
+        }
+
+        echo "${OUTPUT}"
+        echo "::endgroup::"
+
+        # Count packages from JSON output
+        if [[ "${INPUT_OUTPUT_FORMAT}" == "json" || "${INPUT_OUTPUT_FORMAT}" == "" ]]; then
+          PKG_COUNT=$(echo "${OUTPUT}" | jq 'length' 2>/dev/null || echo "unknown")
+          echo "packages_count=${PKG_COUNT}" >> "${GITHUB_OUTPUT}"
+        fi
+
+        # Store report output (truncate for GitHub Actions 1MB limit)
+        TRUNCATED=$(echo "${OUTPUT}" | head -c 900000)
+        {
+          echo "report<<REPORT_EOF"
+          echo "${TRUNCATED}"
+          echo "REPORT_EOF"
+        } >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Two changes:

1. **Add the GitHub composite Action** (`action.yml` + `.github/workflows/action-test.yml`) — wraps the published CLI with inputs mapping to CLI flags (`fail-on`, `only-allow`, `exclude-packages`, `output-format`, …) and `report` / `packages-count` outputs. The test workflow exercises it on Node 18/20/22.
2. **Pin every GitHub Action to a full commit SHA** across all 5 workflows — a supply-chain hardening measure so a moved or hijacked tag can't silently change what runs in CI.

## Pinned actions

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |

Each SHA is the **current head of the major tag previously referenced** (e.g. `@v4`), so CI behavior is unchanged. Version comments (`# v4.3.1`) keep them readable and let Dependabot continue to bump them.

## Scope notes

- `action.yml` is a composite with shell steps only — no external `uses:`, so nothing to pin in it.
- Local `./` references in `action-test.yml` are intentionally left unpinned (they point at this repo).
- Files touched: all 5 workflows (`ci`, `release`, `competitor-tracking`, `npm-stats-report-aws-ses`, `action-test`) + `action.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)