### PR TITLE
chore(release): prep 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 ## [Unreleased]
 
+## [6.3.0] - 2026-05-25
+
 ### 🚀 Features
-- Add opt-in `--spdxSemantics` flag for SPDX-expression-aware `--failOn` and `--onlyAllow` evaluation. Correctly handles dual-licensed packages; default behavior unchanged. ([#2](https://github.com/danshome/license-checker-evergreen/issues/2))
+- Add opt-in `--spdxSemantics` flag for SPDX-expression-aware `--failOn` and `--onlyAllow` evaluation. Correctly handles dual-licensed packages; default behavior unchanged. ([#12](https://github.com/greenstevester/license-checker-evergreen/pull/12))
+- Add `--failOnUnavoidableOnly` (used with `--spdxSemantics`): `--failOn` fails only when a denied license is unavoidable, so `(MIT OR GPL-3.0)` passes when only `GPL-3.0` is denied — the De Morgan dual of `--onlyAllow`. ([#12](https://github.com/greenstevester/license-checker-evergreen/pull/12))
+- Add a GitHub composite action (`action.yml`) for license checking in CI, with inputs mapped to CLI flags and `report` / `packages-count` outputs. ([#11](https://github.com/greenstevester/license-checker-evergreen/pull/11))
+
+### 🐛 Bug Fixes
+- Resolve all 26 `npm audit` advisories (2 critical, 5 high, 18 moderate, 1 low) via non-breaking transitive dependency updates; `package.json` unchanged. ([#10](https://github.com/greenstevester/license-checker-evergreen/pull/10))
+
+### 🔧 Improvements
+- Pin all GitHub Actions to full commit SHAs across every workflow (supply-chain hardening). ([#11](https://github.com/greenstevester/license-checker-evergreen/pull/11))
+- Resolve all ESLint errors (225 → 0) and fix the Jest `read-installed` transform pattern. ([#9](https://github.com/greenstevester/license-checker-evergreen/pull/9))
+
+### 📚 Documentation
+- Rewrite `CLAUDE.md` for the current dual-scanner architecture and document the SPDX flags. ([#9](https://github.com/greenstevester/license-checker-evergreen/pull/9), [#13](https://github.com/greenstevester/license-checker-evergreen/pull/13))
 
 ## [6.2.1] - 2026-04-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "license-checker-evergreen",
-    "version": "6.2.1",
+    "version": "6.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "license-checker-evergreen",
-            "version": "6.2.1",
+            "version": "6.3.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "license-checker-evergreen",
     "description": "NPM license audit and dependency compliance checker - Scan, validate, and analyze open source licenses with SPDX validation. Feature-enhanced, TypeScript-based fork of license-checker with better performance and reliability.",
     "author": "greenstevester",
-    "version": "6.2.1",
+    "version": "6.3.0",
     "license": "BSD-3-Clause",
     "private": false,
     "type": "module",


### PR DESCRIPTION
## Summary

Prepares the **6.3.0** release. Minor bump (`6.2.1` → `6.3.0`) — two new features plus a security fix landed since 6.2.1.

- `package.json` + `package-lock.json` → `6.3.0`
- `CHANGELOG.md` → new `## [6.3.0]` section

## What 6.3.0 ships

- **feat:** `--spdxSemantics` SPDX-aware `--failOn`/`--onlyAllow` + `--failOnUnavoidableOnly` (#12)
- **feat:** GitHub composite action for CI license checking (#11)
- **fix:** all 26 `npm audit` advisories resolved (#10)
- **chore/docs:** lint 225→0, all workflow actions SHA-pinned, CLAUDE.md refreshed (#9, #11, #13)

## ⚠️ This PR does not publish

Releases are cut by pushing a `v*` tag (`release.yml` triggers on it). **Merging this PR alone does nothing externally.** After merge, the publish step is:

```
git tag v6.3.0 && git push origin v6.3.0
```

That's left for you to run when ready — it publishes to npm and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)