### PR TITLE
fix(scanner): preserve all installed versions in fast scanner output (#16)

### DIFF
--- a/__tests__/fastPackageScanner.test.ts
+++ b/__tests__/fastPackageScanner.test.ts
@@ -182,6 +182,30 @@ describe('fastPackageScanner', () => {
       expect(result.packages.has('pkg-b@2.0.0')).toBe(true);
       expect(result.packages.size).toBe(3);
     });
+
+    // Regression for #16: scanPackagesAsync returns result.root, so the OUTPUT
+    // path is result.root.dependencies — not the internal packages Map. Both
+    // versions of pkg-b must survive into result.root, not just the Map.
+    test('keeps both versions in result.root (the shipped output), not just the Map', async () => {
+      const result = await scanPackages({ startPath: tmpDir });
+      const pkgBVersions = Object.values(result.root.dependencies ?? {})
+        .filter((d) => d.name === 'pkg-b')
+        .map((d) => d.version)
+        .sort();
+      expect(pkgBVersions).toEqual(['1.0.0', '2.0.0']);
+    });
+
+    // Invariant: every name@version in the Map must also appear in the shipped
+    // output tree. Directly catches the two-structure divergence behind #16.
+    test('every scanned name@version appears in result.root (Map↔output invariant)', async () => {
+      const result = await scanPackages({ startPath: tmpDir });
+      const outputIds = new Set(
+        Object.values(result.root.dependencies ?? {}).map((d) => `${d.name}@${d.version}`),
+      );
+      for (const key of result.packages.keys()) {
+        expect(outputIds.has(key)).toBe(true);
+      }
+    });
   });
 
   describeWithSymlinks('symlinked packages (pnpm-style)', () => {

--- a/src/lib/fastPackageScanner.ts
+++ b/src/lib/fastPackageScanner.ts
@@ -305,9 +305,12 @@ export async function scanPackages(options: ScanOptions): Promise<ScanResult> {
 		if (!packages.has(key)) {
 			packages.set(key, pkg);
 
-			// Add to root dependencies for tree compatibility
+			// Add to root dependencies for tree compatibility.
+			// Key by name@version (not name) so that multiple installed versions of
+			// the same package are preserved in the output tree rather than the later
+			// one overwriting the earlier — read-installed reports every version (#16).
 			if (rootData.dependencies) {
-				rootData.dependencies[pkg.name] = pkg;
+				rootData.dependencies[key] = pkg;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #16 — the default (fast) scanner silently dropped all-but-one version of any package installed at multiple versions, under-reporting licenses.

## Root cause
`scanPackages` keyed `rootData.dependencies` by **name**, so a second version overwrote the first. The internal `packages` Map was correct (`name@version`), but `scanPackagesAsync` returns `result.root` — and the shipped output walk uses `result.root.dependencies`. So versions collapsed in everything users actually see.

## Fix
One line: key `rootData.dependencies` by `name@version` (the `key` already computed in that loop).

## Why it wasn't caught (and the eval that now catches it)
The existing test *"should find both versions of a nested package"* asserts on `result.packages` (the Map — correct). But production uses `result.root`. **The tests checked a structure that doesn't ship.**

Added **test-first** (verified RED → GREEN):
1. `keeps both versions in result.root (the shipped output)` — asserts on the structure that actually ships
2. `every scanned name@version appears in result.root (Map↔output invariant)` — directly catches the two-structure divergence

## Verification
- New tests: RED before fix, GREEN after
- Full suite: **278 passed**, 0 failed; build clean
- **End-to-end:** fast scan now reports 553 packages == `--legacy`'s 553 (was 493); `ansi-styles` 3.2.1/4.3.0/5.2.0/6.2.3 all present again

## Scope
- `--depth` (#15) is **not** addressed here — it needs the larger nested-tree change and is tracked separately.
- ⚠️ Tests import from `dist/`, so `npm run build` must run before `npm test` (CI does this; bare local `npm test` tests stale `dist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)