### PR TITLE
fix(cli): read version from package.json instead of hardcoded constant (#20)

### DIFF
--- a/__tests__/bin-test.ts
+++ b/__tests__/bin-test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { readFileSync } from 'fs';
 
 const __filename: string = fileURLToPath(import.meta.url);
 const __dirname: string = dirname(__filename);
@@ -20,6 +21,36 @@ describe('bin/license-checker-evergreen', (): void => {
 
 		childProcess.on('exit', function (code: number | null): void {
 			expect(code).toBe(0);
+			done();
+		});
+	});
+
+	// Regression for #20: --version was hardcoded to 6.0.0. Compare against
+	// package.json so the assertion can't drift on future version bumps.
+	test('--version reports the package.json version', (done): void => {
+		const pkgVersion: string = JSON.parse(
+			readFileSync(path.join(__dirname, '../package.json'), 'utf8'),
+		).version;
+
+		const childProcess: ChildProcess = spawn(
+			'node',
+			[path.join(__dirname, '../dist/bin/license-checker-evergreen.js'), '--version'],
+			{
+				cwd: path.join(__dirname, '../'),
+				stdio: ['ignore', 'pipe', 'pipe'],
+			}
+		);
+
+		let output = '';
+		childProcess.stdout?.on('data', (chunk): void => {
+			output += chunk;
+		});
+		childProcess.stderr?.on('data', (chunk): void => {
+			output += chunk;
+		});
+
+		childProcess.on('exit', function (): void {
+			expect(output.trim()).toBe(pkgVersion);
 			done();
 		});
 	});

--- a/src/lib/exitProcessOrWarnIfNeeded.ts
+++ b/src/lib/exitProcessOrWarnIfNeeded.ts
@@ -1,7 +1,12 @@
+import { createRequire } from 'node:module';
 import { usageMessage } from './usageMessage.js';
 import type { ParsedArguments } from './args.js';
 
-const version = '6.0.0';
+// Read the version from package.json so it can't drift from the published version
+// the way the previous hardcoded constant did (#20). Resolves to the package root
+// in both src (../../package.json) and the compiled dist/lib layout.
+const requireCjs = createRequire(import.meta.url);
+const { version } = requireCjs('../../package.json') as { version: string };
 
 interface ExitProcessParams {
 	unknownArgs: string[];


### PR DESCRIPTION
Fixes #20 — `license-checker-evergreen --version` reported `6.0.0` on every release since 6.1.0 (also in the help and unknown-option headers).

## Root cause
`src/lib/exitProcessOrWarnIfNeeded.ts` had `const version = '6.0.0'` — a hardcoded string the release `version-bump` flow never touched (it bumps `package.json`).

## Fix
Read the version from `package.json` via `createRequire` (the pattern already used in `index.ts`). Resolves to the package root in both `src` and the compiled `dist/lib` layout, and in the published tarball.

## Test (added first, RED → GREEN)
`bin-test.ts` spawns the CLI `--version` and asserts the output equals `package.json`'s `version` — a **drift-guard**, not a snapshot of `6.3.0`, so future bumps stay covered.
- RED (before fix): `Expected "6.3.0", Received "6.0.0"`
- GREEN (after fix): passes (162ms)

## Verification
- `node dist/bin/... --version` → `6.3.0` (matches `package.json`)
- Full suite: **279 passed**, 0 failed; lint 0 errors; build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)