### PR TITLE
chore(release): prep 6.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-05-25
+
+### 🐛 Bug Fixes
+- Fast scanner no longer collapses multiple installed versions of a package — it now reports every `name@version` like the legacy scanner, fixing under-reported licenses for packages installed at more than one version. ([#17](https://github.com/greenstevester/license-checker-evergreen/pull/17), closes [#16](https://github.com/greenstevester/license-checker-evergreen/issues/16))
+- `--version` now reports the actual package version instead of a hardcoded `6.0.0`. ([#21](https://github.com/greenstevester/license-checker-evergreen/pull/21), closes [#20](https://github.com/greenstevester/license-checker-evergreen/issues/20))
+
+### 📚 Documentation
+- Refresh README/CHANGELOG: remove phantom flags (`--direct`, `--angularCli`), document `--failOnUnavoidableOnly`, add a `--depth` caveat (see [#15](https://github.com/greenstevester/license-checker-evergreen/issues/15)). ([#19](https://github.com/greenstevester/license-checker-evergreen/pull/19))
+
 ## [6.3.0] - 2026-05-25
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "license-checker-evergreen",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "license-checker-evergreen",
-            "version": "6.3.0",
+            "version": "6.3.1",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "license-checker-evergreen",
     "description": "NPM license audit and dependency compliance checker - Scan, validate, and analyze open source licenses with SPDX validation. Feature-enhanced, TypeScript-based fork of license-checker with better performance and reliability.",
     "author": "greenstevester",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "license": "BSD-3-Clause",
     "private": false,
     "type": "module",


### PR DESCRIPTION
Prepares the **6.3.1** patch release — two correctness fixes (and the docs refresh) landed *after* v6.3.0 was tagged, so npm's current 6.3.0 still has both bugs.

- `package.json` + `package-lock.json` → `6.3.1`
- `CHANGELOG.md` → new `## [6.3.1]` section

## What 6.3.1 ships
- **fix:** fast scanner no longer collapses duplicate-version packages → no more under-reported licenses (#17, closes #16)
- **fix:** `--version` reports the real version instead of hardcoded `6.0.0` (#21, closes #20)
- **docs:** README/CHANGELOG refresh — phantom flags removed, `--failOnUnavoidableOnly` documented, `--depth` caveat (#19)

## ⚠️ This PR does not publish
Releases fire on a `v*` tag push. After merge, the publish step is:
```
git tag v6.3.1 && git push origin v6.3.1
```
Left for you (irreversible / outward-facing). Everything's staged: versions in sync (verified), `--version` now reads `6.3.1` post-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)